### PR TITLE
Patch in https://github.com/dgraph-io/badger/pull/1313 to fix GC after restore.

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -501,3 +501,58 @@ func TestBackupLoadIncremental(t *testing.T) {
 	})
 	require.NoError(t, err, "%v %v", updates, actual)
 }
+
+func TestBackupBitClear(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger-test")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	opt := getTestOptions(dir)
+	opt.ValueThreshold = 10 // This is important
+	db, err := Open(opt)
+	require.NoError(t, err)
+
+	key := []byte("foo")
+	val := []byte(fmt.Sprintf("%0100d", 1))
+	require.Greater(t, len(val), db.opt.ValueThreshold)
+
+	err = db.Update(func(txn *Txn) error {
+		e := NewEntry(key, val)
+		// Value > valueTheshold so bitValuePointer will be set.
+		return txn.SetEntry(e)
+	})
+	require.NoError(t, err)
+
+	// Use different directory.
+	dir, err = ioutil.TempDir("", "badger-test")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	bak, err := ioutil.TempFile(dir, "badgerbak")
+	require.NoError(t, err)
+	_, err = db.Backup(bak, 0)
+	require.NoError(t, err)
+	require.NoError(t, bak.Close())
+	require.NoError(t, db.Close())
+
+	opt = getTestOptions(dir)
+	opt.ValueThreshold = 200 // This is important.
+	db, err = Open(opt)
+	require.NoError(t, err)
+	defer db.Close()
+
+	bak, err = os.Open(bak.Name())
+	require.NoError(t, err)
+	defer bak.Close()
+
+	require.NoError(t, db.Load(bak, 16))
+
+	require.NoError(t, db.View(func(txn *Txn) error {
+		e, err := txn.Get(key)
+		require.NoError(t, err)
+		v, err := e.ValueCopy(nil)
+		require.NoError(t, err)
+		require.Equal(t, val, v)
+		return nil
+	}))
+}

--- a/db.go
+++ b/db.go
@@ -647,8 +647,12 @@ func (db *DB) writeToLSM(b *request) error {
 		if db.shouldWriteValueToLSM(*entry) { // Will include deletion / tombstone case.
 			db.mt.Put(entry.Key,
 				y.ValueStruct{
-					Value:     entry.Value,
-					Meta:      entry.meta,
+					Value: entry.Value,
+					// Ensure value pointer flag is removed. Otherwise, the value will fail
+					// to be retrieved during iterator prefetch. `bitValuePointer` is only
+					// known to be set in write to LSM when the entry is loaded from a backup
+					// with lower ValueThreshold and its value was stored in the value log.
+					Meta:      entry.meta &^ bitValuePointer,
 					UserMeta:  entry.UserMeta,
 					ExpiresAt: entry.ExpiresAt,
 				})


### PR DESCRIPTION
This is a patch of https://github.com/dgraph-io/badger/pull/1313; While the original patch indicates that the fix should only be applicable when `oldOptions.ValueThreshold < newOptions.ValueThreshold`, we seem to hit this case in other situations as well, this patch fixes GC on our restored DBs (I've also verified the # of doc-ids per-corpus after restore).

I've been unable to reproduce this case in our unit-tests (i.e keeping `ValueThreshold` the same between backup/restore) - my suspicions are on some interaction between GC and the restore, but this has been hard to replicate/reproduce.

The other option is to just upgrade to mainline v2.2007 - it looks like it contains a bunch of other fixes that we probably want as well (and which might also be playing a part in causing these inconsistent value-pointer bits):

- Fix for transactions when using iterators: https://github.com/dgraph-io/badger/pull/1328
- Fix for purging expired keys  & deletion markers: https://github.com/dgraph-io/badger/pull/1354
- Avoid re-writing move-markers for deleted keys: https://github.com/dgraph-io/badger/pull/1302

It is a bit more risky to upgrade (ex: we may see a recurrence of the GC issues; mainline v2.2007 is still using an older version of Ristretto, whereas our fork seems to have been upgraded), especially given that this will be the first time we will be exercising the restore path for prod-instances, but we could save time and just do the upgrade now, rather than having to revisit later.